### PR TITLE
add address verification on device

### DIFF
--- a/examples/bcoin-verifyAddress.js
+++ b/examples/bcoin-verifyAddress.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const bledger = require('../lib/bledger');
+const {LedgerBcoin} = bledger;
+const {Device} = bledger.HID;
+const {addressFlags} = LedgerBcoin;
+
+const KeyRing = require('bcoin/lib/primitives/keyring');
+
+(async () => {
+  const devices = await Device.getDevices();
+
+  const device = new Device({
+    device: devices[0],
+    timeout: 60000
+  });
+
+  await device.open();
+
+  const purpose = 44;
+  const coinType = 0;
+  const account = 0;
+  const receivePath = `m/${purpose}'/${coinType}'/${account}'/0/0`;
+
+  const ledgerBcoin = new LedgerBcoin({ device });
+  const hdpub = await ledgerBcoin.getPublicKey(receivePath);
+
+  const ring = KeyRing.fromPublic(hdpub.publicKey);
+  const addr = ring.getAddress();
+
+  console.log('Verify legacy address is the same: ', addr.toString());
+  const verifyLegacy = addressFlags.VERIFY | addressFlags.LEGACY;
+  await ledgerBcoin.getPublicKey(receivePath, verifyLegacy);
+
+  ring.refresh();
+  ring.witness = true;
+  ring.nested = true;
+
+  const nestedAddr = ring.getAddress();
+  const verifyNested = addressFlags.VERIFY | addressFlags.NESTED_WITNESS;
+  console.log('Verify nested address is the same: ', nestedAddr.toString());
+  console.log(await ledgerBcoin.getPublicKey(receivePath, verifyNested));
+
+  ring.refresh();
+  ring.witness = true;
+  ring.nested = false;
+  const bech32Addr = ring.getAddress();
+  const verifyWitness = addressFlags.VERIFY | addressFlags.WITNESS;
+  console.log('Verify bech32 address is the same: ', bech32Addr.toString());
+  console.log(await ledgerBcoin.getPublicKey(receivePath, verifyWitness));
+
+  await device.close();
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -73,12 +73,12 @@ class LedgerBcoin {
    * Get public key
    * @async
    * @param {(Number[]|String)} - Full derivation path
-   * @param {bcoin.Network?} network
+   * @param {apdu.verifyFlags} [addressFlags=0x00]
    * @returns {bcoin.HDPublicKey}
    * @throws {LedgerError}
    */
 
-  async getPublicKey(path, network = this.network) {
+  async getPublicKey(path, addressFlags = 0) {
     assert(this.device);
     assert(path);
 
@@ -88,7 +88,7 @@ class LedgerBcoin {
     assert(Array.isArray(path), 'Path must be string or array');
 
     const indexes = path;
-    const data = await this.ledger.getPublicKey(path);
+    const data = await this.ledger.getPublicKey(path, addressFlags);
     const rawPubkey = data.publicKey;
     const compressedPubkey = secp256k1.publicKeyConvert(rawPubkey, true);
 
@@ -291,5 +291,7 @@ class LedgerBcoin {
     return true;
   }
 }
+
+LedgerBcoin.addressFlags = LedgerBTC.addressFlags;
 
 module.exports = LedgerBcoin;

--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -73,7 +73,7 @@ class LedgerBcoin {
    * Get public key
    * @async
    * @param {(Number[]|String)} - Full derivation path
-   * @param {apdu.verifyFlags} [addressFlags=0x00]
+   * @param {apdu.addressFlags} [addressFlags=0x00]
    * @returns {bcoin.HDPublicKey}
    * @throws {LedgerError}
    */

--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -43,11 +43,12 @@ class LedgerBTCApp {
    * Get public key
    * @async
    * @param {(Number[]|String)} - Full derivation path
+   * @param {apdu.addressFlags} - Verify and address types
    * @returns {Object} - publicKey, chainCode
    * @throws {LedgerError}
    */
 
-  async getPublicKey(path) {
+  async getPublicKey(path, addressFlags) {
     assert(this.device);
 
     if (typeof path === 'string')
@@ -56,7 +57,7 @@ class LedgerBTCApp {
     assert(Array.isArray(path), 'Path must be string or array');
 
     const indexes = path;
-    const command = APDUCommand.getPublicKey(indexes);
+    const command = APDUCommand.getPublicKey(indexes, addressFlags);
     const responseBuffer = await this.device.exchange(command.toRaw());
     const response = APDUResponse.getPublicKey(responseBuffer);
 
@@ -325,5 +326,7 @@ class LedgerBTCApp {
     return APDUResponse.hashSign(res).data;
   }
 }
+
+LedgerBTCApp.addressFlags = LedgerProtocol.APDU.addressFlags;
 
 module.exports = LedgerBTCApp;

--- a/lib/protocol/apdu.js
+++ b/lib/protocol/apdu.js
@@ -19,6 +19,26 @@ const apdu = exports;
 apdu.EMPTY = Buffer.alloc(0);
 
 /**
+ * Adress verification flags
+ * @const
+ */
+apdu.addressFlags = {
+  // address types, choose one
+  LEGACY: 0,
+  NESTED_WITNESS: 1 << 0,
+  WITNESS: 1 << 1,
+
+  // whether to verify
+  VERIFY: 1 << 2
+};
+
+/**
+ * Address type mask least 2 bits
+ * @const
+ */
+apdu.addressTypeMask = 0x03;
+
+/**
  * Maximum depth of HD Path
  * @const {Number}
  */
@@ -205,14 +225,20 @@ class APDUCommand {
 
   /**
    * Get wallet public key
-   * @param {Number[]}
+   * @param {Number[]} path
+   * @param {apdu.addressFlags} [verifyFlags=0]
    * @returns {APDUCommand}
    */
 
-  static getPublicKey(path) {
+  static getPublicKey(path, addressFlags) {
     const data = encodePath(path);
 
     return new APDUCommand({
+      // verify ?
+      p1: (addressFlags & apdu.addressFlags.VERIFY) >> 2,
+      // address type
+      p2: addressFlags & apdu.addressTypeMask,
+
       cla: apdu.CLA.GENERAL,
       ins: apdu.INS.PUBLIC_KEY,
 

--- a/lib/protocol/apdu.js
+++ b/lib/protocol/apdu.js
@@ -21,6 +21,7 @@ apdu.EMPTY = Buffer.alloc(0);
 /**
  * Adress verification flags
  * @const
+ * @see https://github.com/LedgerHQ/blue-app-btc/blob/master/src/btchip_apdu_get_wallet_public_key.c#L36
  */
 apdu.addressFlags = {
   // address types, choose one
@@ -226,7 +227,7 @@ class APDUCommand {
   /**
    * Get wallet public key
    * @param {Number[]} path
-   * @param {apdu.addressFlags} [verifyFlags=0]
+   * @param {apdu.addressFlags} [addressFlags=0]
    * @returns {APDUCommand}
    */
 


### PR DESCRIPTION
**Based on [cleanup](https://github.com/bcoin-org/bledger/pull/5) branch**

* Verifies address on device screen for `LEGACY`, `WITNESS` and `Nested Witness` addresses.