### PR TITLE
Polymorphic redeem script support

### DIFF
--- a/lib/txinput.js
+++ b/lib/txinput.js
@@ -30,7 +30,7 @@ class LedgerTXInput {
    * @param {String|Number[]} options.path
    * @param {bcoin.TX|Buffer} options.tx
    * @param {Number} options.index
-   * @param {bcoin.Script?} options.redeem - Redeem script for P2SH transactions
+   * @param {bcoin.Script|Buffer?} options.redeem - Redeem script for P2SH transactions
    * @param {Buffer?} options.publicKey - raw public key for ring
    * @param {Boolean} [options.witness=false]
    * @param {bcoin.SighashType} [options.type=SIGHASH_ALL]
@@ -90,6 +90,8 @@ class LedgerTXInput {
     }
 
     if (options.redeem != null) {
+      if (Buffer.isBuffer(options.redeem))
+        options.redeem = Script.fromRaw(options.redeem);
       assert(Script.isScript(options.redeem), 'Cannot use non-script redeem.');
       this.redeem = options.redeem;
     }


### PR DESCRIPTION
When creating a `bcoin.Script` from outside of the `bledger` library, the `assert` fails.

This allows a developer to pass in a raw script so that it can be turned into
a `bcoin.Script` using the correct instance of `bcoin`

This is similar to `options.tx`