### PR TITLE
Handle 65 symbols in prevout key

### DIFF
--- a/lib/ledger.js
+++ b/lib/ledger.js
@@ -135,7 +135,7 @@ class LedgerBTCApp {
 
       // TODO: remove after bcoin@next
       if (typeof prevoutKey === 'string')
-        prevoutKey = Buffer.from(prevoutKey, 'hex');
+        prevoutKey = Buffer.from(prevoutKey.padEnd(66, '0'), 'hex');
 
       let buffer;
 
@@ -243,7 +243,7 @@ class LedgerBTCApp {
 
       // TODO: remove after bcoin@next
       if (typeof prevoutKey === 'string')
-        prevoutKey = Buffer.from(prevoutKey, 'hex');
+        prevoutKey = Buffer.from(prevoutKey.padEnd(66, '0'), 'hex');
 
       if (prevoutKey.equals(key))
         input.script = prev;
@@ -279,7 +279,7 @@ class LedgerBTCApp {
 
       // TODO: remove after bcoin@next
       if (typeof prevoutKey === 'string')
-        prevoutKey = Buffer.from(prevoutKey, 'hex');
+        prevoutKey = Buffer.from(prevoutKey.padEnd(66, '0'), 'hex');
 
       if (prevoutKey.equals(key)) {
         input.script = prev;

--- a/lib/txinput.js
+++ b/lib/txinput.js
@@ -167,7 +167,11 @@ class LedgerTXInput {
   toKey() {
     if (!this._key) {
       const key = this.getOutpoint().toKey();
-      this._key = key;
+      // TODO: remove after bcoin@next
+      if (typeof key === 'string')
+        this._key = Buffer.from(key.padEnd(66, '0'), 'hex');
+      else
+        this._key = key;
     }
 
     return this._key;

--- a/lib/txinput.js
+++ b/lib/txinput.js
@@ -167,12 +167,7 @@ class LedgerTXInput {
   toKey() {
     if (!this._key) {
       const key = this.getOutpoint().toKey();
-
-      // TODO: remove after bcoin@next
-      if (typeof key === 'string')
-        this._key = Buffer.from(key, 'hex');
-      else
-        this._key = key;
+      this._key = key;
     }
 
     return this._key;

--- a/lib/txstate.js
+++ b/lib/txstate.js
@@ -354,7 +354,7 @@ function prepareLegacyTX(tx, key, prev) {
 
     // TODO: remove after bcoin@next
     if (typeof prevoutKey === 'string')
-      prevoutKey = Buffer.from(prevoutKey, 'hex');
+      prevoutKey = Buffer.from(prevoutKey.padEnd(66, '0'), 'hex');
 
     if (prevoutKey.equals(key))
       input.script = prev;

--- a/lib/txstate.js
+++ b/lib/txstate.js
@@ -141,7 +141,7 @@ class LedgerTXState {
 
       // TODO: remove after bcoin@next
       if (typeof key === 'string')
-        key = Buffer.from(key, 'hex');
+        key = Buffer.from(key.padEnd(66, '0'), 'hex');
 
       assert(Buffer.isBuffer(key));
 

--- a/lib/txstate.js
+++ b/lib/txstate.js
@@ -386,7 +386,7 @@ function prepareWitnessTX(tx, key, prev) {
 
     // TODO: remove after bcoin@next
     if (typeof prevoutKey === 'string')
-      prevoutKey = Buffer.from(prevoutKey, 'hex');
+      prevoutKey = Buffer.from(prevoutKey.padEnd(66, '0'), 'hex');
 
     if (prevoutKey.equals(key)) {
       input.script = prev;


### PR DESCRIPTION
`bledger` provides `prevout` key as 64 bytes plus 1 symbol as output index. `bledger` can not handle that correctly. The pull request handles that using padding. Now the code sets `bledger` internal key as Buffer containing 33 bytes.