### PR TITLE
app: get public key depth 0 bugfix

### DIFF
--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -95,9 +95,13 @@ class LedgerBcoin {
     const rawPubkey = data.publicKey;
     const compressedPubkey = secp256k1.publicKeyConvert(rawPubkey, true);
 
+    // indexes is empty when depth is 0
+    const childIndex = indexes.length ?
+      indexes[indexes.length - 1] : 0;
+
     return new HDPublicKey({
       depth: indexes.length,
-      childIndex: indexes[indexes.length - 1],
+      childIndex: childIndex,
       parentFingerPrint: 0,
       chainCode: data.chainCode,
       publicKey: compressedPubkey,

--- a/test/device/general.js
+++ b/test/device/general.js
@@ -77,6 +77,15 @@ module.exports = function (Device, DeviceInfo) {
       }
     });
 
+    it('should get public key at depth 0', async () => {
+      const hd = await bcoinApp.getPublicKey(m);
+
+      assert.ok(hd);
+      assert.equal(hd.depth, 0);
+      assert.equal(hd.childIndex, 0);
+      assert.equal(hd.parentFingerPrint, 0);
+    });
+
     it('should sign simple p2pkh transaction', async () => {
       const path = PATH1;
       const pubHD = await bcoinApp.getPublicKey(path);


### PR DESCRIPTION
This allows for the functionality of pulling the master public key from the bcoin app, since `indexes` would be empty and `indexes[indexes.length - 1]` would result in `undefined`, it would break `new HDPublicKey` since there is an assertion on `childIndex` being an integer

This is the first step towards associating each bcoin app with the bip174 `fingerprint`, so that they can use that as an identifier