### PR TITLE
WIP:  fromOptions populates fingerprint

### DIFF
--- a/lib/bcoin.js
+++ b/lib/bcoin.js
@@ -18,6 +18,7 @@ const MTX = require('bcoin/lib/primitives/mtx');
 const CoinView = require('bcoin/lib/coins/coinview');
 const HDPublicKey = require('bcoin/lib/hd/public');
 const secp256k1 = require('bcrypto').secp256k1;
+const hash160 = require('bcrypto/lib/hash160');
 
 const {Device} = require('./devices/device');
 const LedgerBTC = require('./ledger');
@@ -310,6 +311,20 @@ class LedgerBcoin {
     vector.fromStack(result);
 
     return true;
+  }
+
+  static async fromOptions(options) {
+    const ledgerBcoin = new this(options);
+
+    if (!options.fingerprint) {
+      const data = await ledgerBcoin.getPublicKey('M');
+      const compressed = secp256k1.publicKeyConvert(data.publicKey, true);
+      const hash = hash160.digest(compressed);
+      const fp = hash.readUInt32BE(0);
+      ledgerBcoin.fingerprint = fp;
+    }
+
+    return ledgerBcoin;
   }
 }
 


### PR DESCRIPTION
I'd like some feedback on the API, but a small change to populate the `ledgerBcoin` class with the master public key's fingerprint when initialized `fromOptions`.  This uses the fingerprint code from https://github.com/bcoin-org/bledger/pull/34

Since fetching the public key is async, it can't go in the constructor. Do you have any alternative ideas for how to do this? Its only 1 async call during the device initialization, so I do not believe that it will be that large of a performance issue.

I could have my app populate the `fingerprint` but if fingerprints become first class citizens with bip174, then I think other people may find them useful as well

TODO, pending feedback:
- set `this.fingerprint = null;` in the constructor
- docstrings