### PR TITLE
Reducing dependency tree size with custom node-hid fork

### DIFF
--- a/lib/devices/ledgerhid.js
+++ b/lib/devices/ledgerhid.js
@@ -8,7 +8,7 @@
 
 const assert = require('bsert');
 
-const HID = require('node-hid');
+const HID = require('node-hid-ng');
 const {Lock} = require('bmutex');
 
 const Logger = require('blgr');

--- a/lib/devices/ledgerhid.js
+++ b/lib/devices/ledgerhid.js
@@ -97,7 +97,7 @@ class HIDDevice extends Device {
     this.enforce(this.devicePath, 'Device is not configured');
     this.enforce(!this.device, 'Device already exists');
 
-    this.device = new HID.HID(this.devicePath);
+    this.device = new HID(this.devicePath);
     this.opened = true;
     this.closed = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,40 +16,43 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
     },
     "bcfg": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.4.tgz",
-      "integrity": "sha512-tgweKJnFlFqg/QA3l+9i4cSJTHPcABrBriRZkUd+MM9mUCv8tBqAZFoykR0Cn3Fi9ygJ/pyWfmjDkRVZQwvPkQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.6.tgz",
+      "integrity": "sha512-BR2vwQZwu24aRm588XHOnPVjjQtbK8sF0RopRFgMuke63/REJMWnePTa2YHKDBefuBYiVdgkowuB1/e4K7Ue3g==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bclient": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/bclient/-/bclient-0.1.5.tgz",
-      "integrity": "sha512-LtlH6i66dVIztUVyd2ItU3sRwNT/+X/zIEXP5wxz8boP0tARIRjCB1THoYg6PtPaONZ+k/W2VkzYl9XjWTsOpQ==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bclient/-/bclient-0.1.7.tgz",
+      "integrity": "sha512-tD1b48VGrJ10Hkv1Slew88DLcIBAYbhjGIwO7fRPp0mTcc5jZjGhFjsrHwgPsChj9HYctA8yMw/ChGfheqZGDA==",
       "dev": true,
       "requires": {
-        "bcfg": "~0.1.4",
-        "bcurl": "~0.1.4",
-        "bsert": "~0.0.5"
+        "bcfg": "~0.1.6",
+        "bcurl": "~0.1.6",
+        "bsert": "~0.0.10"
       }
     },
     "bcoin": {
@@ -100,17 +103,6 @@
             "secp256k1": "3.5.0"
           }
         },
-        "bstring": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.2.tgz",
-          "integrity": "sha512-n7FeLSrKfsPnZstqA9PfPME1apI9u9WB35aDbsubWzLz1GjpgXewCXYyq9/m8c/IB/pFXRwqs0XwL/qq5IGJPQ==",
-          "dev": true,
-          "requires": {
-            "bindings": "~1.3.0",
-            "bsert": "~0.0.3",
-            "nan": "~2.10.0"
-          }
-        },
         "bufio": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
@@ -119,7 +111,7 @@
         },
         "nan": {
           "version": "2.10.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         }
@@ -134,24 +126,17 @@
         "bufio": "~1.0.6",
         "loady": "~0.0.1",
         "nan": "^2.13.1"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-        }
       }
     },
     "bcurl": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.4.tgz",
-      "integrity": "sha512-wy+/9uBQWrcNcMy4qCl241qATNnB0evBO5oTJboINXXG3c152wDyEnedAvypkOp4Mh0fYrlsO6yYr5RmRXnVIQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.6.tgz",
+      "integrity": "sha512-noeDhfqFiUcNOUuZKErkXcbZfxBjn6duTfYPEfA4hAYXGr7gwVxkAWvIerxl3ZLLyn8jzh7Oi0nHlrLm1ST9Fw==",
       "dev": true,
       "requires": {
-        "brq": "~0.1.4",
-        "bsert": "~0.0.5",
-        "bsock": "~0.1.4"
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
       }
     },
     "bdb": {
@@ -165,27 +150,27 @@
       }
     },
     "bdns": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.3.tgz",
-      "integrity": "sha512-d071TLX00NZCqhKNspsKU8N8ApqqVizSEdEB7bCE5tUQgFS1UMHjnN0C8HDd5kRYwIX3jAIsN+oNgREvZCGOcA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bevent": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.3.tgz",
-      "integrity": "sha512-bTsC1MSSWxn0E0OrjrY8j/Sz/C2u3FuAhaO2CaEyc5a5uLwcvC8MK9b14oW0fW/k0AGKQHkuebJOI1RRzArBFQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bfile": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.3.tgz",
-      "integrity": "sha512-7OScx3u416zFsloaN2CyVXRwVAOJdFBpNrpvGlUbkVD2gEzpj+d7/38MInEXnFtcmErDiY1DFR2URBT4J/7kRg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.4.tgz",
+      "integrity": "sha512-pqeG3lJbWAlYlphNzMQA/VeUNGaq7Zopvzl8hbYXzIXLIFdPqC2h2hCbZHzRlLnnaUfipmuqwWYr3qbulbuu6Q==",
       "dev": true
     },
     "bfilter": {
@@ -207,27 +192,28 @@
       }
     },
     "bheep": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.3.tgz",
-      "integrity": "sha512-Epqqqokl8M0o2qPx/3Z4OPxzGVFmp3JTQubzoUfWD7uucx5x3opRvcPA/UltLrSL9/b2LA+KIg1s/zyPlpGyrQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bindings": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+      "dev": true
     },
     "binet": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.3.tgz",
-      "integrity": "sha512-EQX5k4WfYDkDhiKyK11Z90jkTLC9yAw4luSpr7+zfT0VW+/fy4Zizf3FoRyAtI7CWV803NybAcfDZz94wAtziA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.5.tgz",
+      "integrity": "sha512-suogkqXrt63Z76ABvwJjI28w+LWrRE53nwItDPz1VwNjHEuh1+rxudGYtoewFmMhkJ9pW/VGGnjoxP+AGzHgLQ==",
       "dev": true,
       "requires": {
-        "bs32": "~0.1.3",
-        "bsert": "~0.0.5"
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
       }
     },
     "bip66": {
@@ -241,8 +227,9 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -257,21 +244,21 @@
       }
     },
     "blru": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.4.tgz",
-      "integrity": "sha512-qq82TVa2GDcjv/BswxH7hpDZEr2Cu8XLVoHmLt7jZMAHKZ3jzTtyQCsuUOZXILpOwduqB8AC6R79bvclNWwRKw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "blst": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.3.tgz",
-      "integrity": "sha512-bDZC68tjfflVuC7OGy+vlF6VtlW1Jtk8isH2116LoCLE9MCgTu2N2yTaT5CFuUF3yB1s0gGiWVR3uJpF+27HFw==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bmocha": {
@@ -302,7 +289,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -315,21 +302,21 @@
       }
     },
     "brq": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.4.tgz",
-      "integrity": "sha512-VPQtZgDjc3awXuzpuGrjuJtqsImDKrj7z4tVWC2bMafutD4Efx50otZMyxvQzJlQz3kXK3uAKonrHLKWy0Yo+A==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.7.tgz",
+      "integrity": "sha512-mFoSpFJx7pI8IfuNojIul7Bto4Wcp1a7SOj8MTV4Qsd6Jg3leHJFzSlTcnKfG8BIOg46nvEFDXdLmM0v0YwEPQ==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bs32": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.3.tgz",
-      "integrity": "sha512-pTVLcFJxmAUMjtfLqaBkqCPybquBQCjxKcpVIYEDqPpXIabctuNTnK+6W4Z8WcGyLJijkAWU9ZOI9xARexT8uQ==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.5.tgz",
+      "integrity": "sha512-YR9OXFjx8qmW/TpuJKc1RSdzRogpCYh1ygCSMi5Z3fG2QkP+Ra1IfcHsICqd/I/tmFAtc7ov8BpEyN8HJD7jlw==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bsert": {
@@ -338,45 +325,65 @@
       "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
     },
     "bsip": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.4.tgz",
-      "integrity": "sha512-ZC5Dsa5k1+24DorSOgXeDgV9f7OxLcvZiXDYYjHN1mkW8OF/abNSKlogDgVrx/znpAAZ1yJPkWgrub/FsIxEmA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.8.tgz",
+      "integrity": "sha512-R6rRgLOWjSITqp1C9yzPuPfzKgXANP+5Ip6OoLCIhmaybaVywHhINNfO0L2zFKJgS+vfLHGFltip14bKvTNVGA==",
       "dev": true,
       "requires": {
-        "bindings": "~1.3.1",
-        "bsert": "~0.0.5",
-        "nan": "~2.11.1"
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
       }
     },
     "bsock": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.4.tgz",
-      "integrity": "sha512-3hfPScf58kC13udMqXL/GiBubUOmwwMaTljIY8xJI0pO2uOmAaDyBCqT/PiteXRHHC1lDinK2wkFayc4xX92Wg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.8.tgz",
+      "integrity": "sha512-+rdqLWVnbYFhUTvgDuzO3KlGYXWOVS2RhRgHrRx26wSiNgmyYJSX4hK+PwtI1hEc9cyIb28Qt/hgPgSrqPlDNw==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bsocks": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.3.tgz",
-      "integrity": "sha512-Mc6yqYNqPHaZkYYppCctrsZUmoISGBZQmjKnd4P8xxKeKH4KnM0JZJigF6y0QTRjq+e/+7AvSSxoSsUeGh7CYQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.5.tgz",
+      "integrity": "sha512-w1yG8JmfKPIaTDLuR9TIxJM2Ma6nAiInRpLNZ43g3qPnPHjawCC4SV6Bdy84bEJQX1zJWYTgdod/BnQlDhq4Gg==",
       "dev": true,
       "requires": {
-        "binet": "~0.3.3",
-        "bsert": "~0.0.5"
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bstring": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.1.2.tgz",
+      "integrity": "sha512-n7FeLSrKfsPnZstqA9PfPME1apI9u9WB35aDbsubWzLz1GjpgXewCXYyq9/m8c/IB/pFXRwqs0XwL/qq5IGJPQ==",
+      "dev": true,
+      "requires": {
+        "bindings": "~1.3.0",
+        "bsert": "~0.0.3",
+        "nan": "~2.10.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
+        }
       }
     },
     "btcp": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.3.tgz",
-      "integrity": "sha512-5UV2yOHOwpIhAVqUqiC7MyHdX4coTJPcOnJik3guV+99cVo5ZK/2oKb/w+e2PBxLrsy2c93EF5/DamzmG1QqSA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A==",
       "dev": true
     },
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -385,12 +392,14 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
     },
     "buffer-map": {
       "version": "0.0.7",
@@ -409,39 +418,40 @@
       "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
     },
     "bupnp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.4.tgz",
-      "integrity": "sha512-7H1zZkX4Jba+CmY1sxAuceIZoEXAYGi767chlBrGfqFwwf1Bt4DYMsAw65Xxdu/zsLd2nsUSXliV20Txdf76xw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
       "dev": true,
       "requires": {
-        "binet": "~0.3.3",
-        "brq": "~0.1.4",
-        "bsert": "~0.0.5"
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
       }
     },
     "bval": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.4.tgz",
-      "integrity": "sha512-mCPe86NoWCCO/W4Yvx6dfA2Tr45wP3NAKCeZvwN01ODj5ecdllaD/UHthVjH16/yZa59nxtrA2sBi6Mi83QmXg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5"
+        "bsert": "~0.0.10"
       }
     },
     "bweb": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.6.tgz",
-      "integrity": "sha512-Fuyi0DrtpeQbXO0Srg8JtHWM+t5/XPFcXcXcu61zU3lVeYrYdcITu6+I+qKy6v9esRWbvc+yh117lz9/Wm/Qnw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.8.tgz",
+      "integrity": "sha512-xGMDbVf3JnLka7VTWOiy5GMersZcAuUMtd97zs7OUA/rrt2Z8bWVAwzCVPFxVzYMreYu7M+W3NZCJSpUdd7umA==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.5",
-        "bsock": "~0.1.4"
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
       }
     },
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -456,21 +466,24 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -483,7 +496,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -499,6 +512,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -506,17 +520,20 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -548,6 +565,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -563,10 +581,10 @@
       }
     },
     "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "optional": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "dev": true
     },
     "fast-future": {
       "version": "1.0.2",
@@ -577,12 +595,14 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -597,12 +617,14 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "hash-base": {
       "version": "3.0.4",
@@ -638,17 +660,20 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -656,7 +681,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "leveldown": {
       "version": "4.0.1",
@@ -671,40 +697,11 @@
         "prebuild-install": "^4.0.0"
       },
       "dependencies": {
-        "expand-template": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-          "dev": true
-        },
         "nan": {
           "version": "2.10.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
-        },
-        "prebuild-install": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
-          "dev": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
         }
       }
     },
@@ -727,7 +724,8 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -743,80 +741,77 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
     "mrmr": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.4.tgz",
-      "integrity": "sha512-i2kWXVPLExnVOO7qP861WZxK+pfJ9Rppujfl7lS5sfqWSvQbNz8OouEUgcVk6EsRiH4tDHx6yM6LQQhl0jrjXw==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.8.tgz",
+      "integrity": "sha512-lNav10EJsPZvlMqlBOYQ5atIO9jrlvbJ4/7asqunXY89dHooN5c+W6AV7jtvBRw4wFDR7TpEWfmBQgRGRVwBzA==",
       "dev": true,
       "requires": {
-        "bindings": "~1.3.1",
-        "bsert": "~0.0.5",
-        "nan": "~2.11.1"
+        "bsert": "~0.0.10",
+        "loady": "~0.0.1",
+        "nan": "^2.13.1"
       }
     },
     "n64": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.5.tgz",
-      "integrity": "sha512-wry9grq4tNsxvpW2hqXNJIxqv9pT3+NEs/nyg9z5nKQ4QCB6b9IF2DSpVBEC/9fxX6c6G5hJ+SzK/Iv2k+896w==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.9.tgz",
+      "integrity": "sha512-Fr71HDRSClfgPloQupVBHTx5k8PXyw4yLBj3Q7/C4qhS4r5hWrjScuZg1qCDWqzHf0vxSq8lXbinb6T0oPLdHA==",
       "dev": true
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
-    },
-    "napi-build-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
-      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
-      "optional": true
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "node-abi": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
-      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
+      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+      "dev": true,
       "requires": {
         "semver": "^5.4.1"
       }
     },
     "node-hid": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.7.4.tgz",
-      "integrity": "sha512-gvgNDPoszObn7avIDYMUvVv1T0xQB4/CZFJWckra/LXAc0qHYho4M1LCnCKlLIocL2R5/3qGv0J4AjRMdwgjxg==",
-      "optional": true,
+      "version": "git+https://github.com/bcoin-org/node-hid-ng.git#7d2a08e46379ff0216c0b7b7ff7ea952c30fd56d",
+      "from": "git+https://github.com/bcoin-org/node-hid-ng.git#master",
       "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.10.0",
-        "prebuild-install": "^5.2.1"
+        "loady": "0.0.1",
+        "nan": "^2.13.1"
       }
     },
     "noop-logger": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -827,44 +822,47 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "prebuild-install": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.2.tgz",
-      "integrity": "sha512-4e8VJnP3zJdZv/uP0eNWmr2r9urp4NECw7Mt1OSAi3rcLrbBRxGiAkfUFtre2MhQ5wfREAjRV+K1gubvs/GPsA==",
-      "optional": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
+      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "napi-build-utils": "^1.0.1",
         "node-abi": "^2.2.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "os-homedir": "^1.0.1",
         "pump": "^2.0.1",
-        "rc": "^1.2.7",
+        "rc": "^1.1.6",
         "simple-get": "^2.7.0",
         "tar-fs": "^1.13.0",
         "tunnel-agent": "^0.6.0",
@@ -874,12 +872,14 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -889,6 +889,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -898,8 +899,9 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -923,7 +925,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "secp256k1": {
       "version": "3.5.0",
@@ -942,18 +945,20 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -964,17 +969,20 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "simple-concat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
     },
     "simple-get": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "dev": true,
       "requires": {
         "decompress-response": "^3.3.0",
         "once": "^1.3.1",
@@ -985,6 +993,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -993,16 +1002,18 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -1010,12 +1021,14 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "dev": true,
       "requires": {
         "chownr": "^1.0.1",
         "mkdirp": "^0.5.1",
@@ -1027,6 +1040,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -1038,6 +1052,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -1051,36 +1066,41 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "u2f-api": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-1.0.9.tgz",
-      "integrity": "sha512-Z+UvXlES6+o+6tzBv3Rg4VfzvOw6MEQtciiAsB4YVEXAh6R23NCdiqaUmb7xHfEc+VEowWtMMth+ME7nBANwvA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/u2f-api/-/u2f-api-1.0.10.tgz",
+      "integrity": "sha512-0Zh+IqM2l6xaA/IUJDT9WwoEM6nwPx6ive4flVVYEfzzgXIrKFRaenieItsEkbXIgOZEw13nO3o3oLtSDOyesA==",
       "optional": true
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
@@ -1088,12 +1108,14 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,9 +794,10 @@
       }
     },
     "node-hid-ng": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-hid-ng/-/node-hid-ng-1.0.0.tgz",
-      "integrity": "sha512-wI4wDCg5k+LbT218FFq1Lq+VCjx9HHJtLGdqxzrYRjT9AncoCGYxJCrk5KcXIktHxUFA7M/kAt66z5GbhjzLxQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-hid-ng/-/node-hid-ng-1.0.1.tgz",
+      "integrity": "sha512-vkLQ8sFRuF8rwGl84wAO8O85nqzocsK+VlEk1HQfrrtmQsRK3/c8GyFTUbr4sEueQccNytyeQ//FPUrKFQIO6A==",
+      "optional": true,
       "requires": {
         "loady": "0.0.1",
         "nan": "^2.13.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "bcrypto": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.5.tgz",
-      "integrity": "sha512-t0RLK+AxzmZ0hFHReX4SWOUL+fSGizd3PPmls1JoCaZpKXjm1oaZEXPreYpkhTyU7pawnH+ILVieANfv65S7bg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-3.1.6.tgz",
+      "integrity": "sha512-k6a8UfSQVdtZMav2kLxrw1Kq2PqphEs8aUeW0PW5s2RHMLN4pp57MgIUzLrtlBJipZ3f1mjnstLGPIRKYPLCTw==",
       "requires": {
         "bsert": "~0.0.10",
         "bufio": "~1.0.6",
@@ -785,17 +785,18 @@
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "node-abi": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
-      "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.8.0.tgz",
+      "integrity": "sha512-1/aa2clS0pue0HjckL62CsbhWWU35HARvBDXcJtYKbYR7LnIutmpxmXbuDMV9kEviD2lP/wACOgWmmwljghHyQ==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"
       }
     },
-    "node-hid": {
-      "version": "git+https://github.com/bcoin-org/node-hid-ng.git#7d2a08e46379ff0216c0b7b7ff7ea952c30fd56d",
-      "from": "git+https://github.com/bcoin-org/node-hid-ng.git#master",
+    "node-hid-ng": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-hid-ng/-/node-hid-ng-1.0.0.tgz",
+      "integrity": "sha512-wI4wDCg5k+LbT218FFq1Lq+VCjx9HHJtLGdqxzrYRjT9AncoCGYxJCrk5KcXIktHxUFA7M/kAt66z5GbhjzLxQ==",
       "requires": {
         "loady": "0.0.1",
         "nan": "^2.13.1"

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "bmutex": "^0.1.6",
     "bsert": "0.0.10",
     "buffer-map": "0.0.7",
-    "bufio": "^1.0.6"
+    "bufio": "^1.0.6",
+    "node-hid": "git+https://github.com/bcoin-org/node-hid-ng.git#master"
   },
   "optionalDependencies": {
-    "node-hid": "^0.7.3",
     "u2f-api": "^1.0.8"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     "./lib/bledger": "./lib/bledger-browser.js"
   },
   "dependencies": {
-    "bcrypto": "^3.1.5",
+    "bcrypto": "^3.1.6",
     "blgr": "^0.1.7",
     "bmutex": "^0.1.6",
     "bsert": "0.0.10",
     "buffer-map": "0.0.7",
     "bufio": "^1.0.6",
-    "node-hid": "git+https://github.com/bcoin-org/node-hid-ng.git#master"
+    "node-hid-ng": "^1.0.0"
   },
   "optionalDependencies": {
     "u2f-api": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "bmutex": "^0.1.6",
     "bsert": "0.0.10",
     "buffer-map": "0.0.7",
-    "bufio": "^1.0.6",
-    "node-hid-ng": "^1.0.0"
+    "bufio": "^1.0.6"
   },
   "optionalDependencies": {
+    "node-hid-ng": "^1.0.1",
     "u2f-api": "^1.0.8"
   },
   "peerDependencies": {


### PR DESCRIPTION
node_modules on master (all/--production): 125/72
node_modules on this branch (all/--production): 119/14

I have not validated all tests since I am lacking a proper test ledger, but initial testing appears everything works.

NOTE: Currently this uses a direct github link in package.json for `node-hid-ng`. I intend to do a proper npm release once this change is validated.